### PR TITLE
Add user to memcached command

### DIFF
--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -2,7 +2,7 @@ varnishtest "Test set and get"
 
 feature cmd "command -v memcached >/dev/null"
 
-process p1 "exec memcached -u memcached -p -1 -U 0" -start
+process p1 "exec memcached -u nobody -p -1 -U 0" -start
 
 shell {${vmod_topsrc}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test set and get"
 
-process p1 "exec memcached -p -1 -U 0" -start
+process p1 "exec memcached -u memcached -p -1 -U 0" -start
 
 shell {${vmod_topbuild}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test incr and decr"
 
-process p1 "exec memcached -p -1 -U 0" -start
+process p1 "exec memcached -u memcached -p -1 -U 0" -start
 
 shell {${vmod_topbuild}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -2,7 +2,7 @@ varnishtest "Test incr and decr"
 
 feature cmd "command -v memcached >/dev/null"
 
-process p1 "exec memcached -u memcached -p -1 -U 0" -start
+process p1 "exec memcached -u nobody -p -1 -U 0" -start
 
 shell {${vmod_topsrc}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test03.vtc
+++ b/src/tests/test03.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test invalid get with error_string"
 
-process p1 "exec memcached -p -1 -U 0" -start
+process p1 "exec memcached -u memcached -p -1 -U 0" -start
 
 shell {${vmod_topbuild}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test03.vtc
+++ b/src/tests/test03.vtc
@@ -2,7 +2,7 @@ varnishtest "Test invalid get with error_string"
 
 feature cmd "command -v memcached >/dev/null"
 
-process p1 "exec memcached -u memcached -p -1 -U 0" -start
+process p1 "exec memcached -u nobody -p -1 -U 0" -start
 
 shell {${vmod_topsrc}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test04.vtc
+++ b/src/tests/test04.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test invalid incr"
 
-process p1 "exec memcached -p -1 -U 0" -start
+process p1 "exec memcached -u memcached -p -1 -U 0" -start
 
 shell {${vmod_topbuild}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test04.vtc
+++ b/src/tests/test04.vtc
@@ -2,7 +2,7 @@ varnishtest "Test invalid incr"
 
 feature cmd "command -v memcached >/dev/null"
 
-process p1 "exec memcached -u memcached -p -1 -U 0" -start
+process p1 "exec memcached -u nobody -p -1 -U 0" -start
 
 shell {${vmod_topsrc}/src/tests/gen-vcl.sh ${p1_pid} "--SERVER=@SERVER@"}
 

--- a/src/tests/test05.vtc
+++ b/src/tests/test05.vtc
@@ -2,7 +2,7 @@ varnishtest "Test incr_set and decr_set"
 
 feature cmd "command -v memcached >/dev/null"
 
-process p1 "exec memcached -u memcached -p -1 -U 0" -start
+process p1 "exec memcached -u nobody -p -1 -U 0" -start
 
 shell {
 	${vmod_topsrc}/src/tests/gen-vcl.sh ${p1_pid} \

--- a/src/tests/test05.vtc
+++ b/src/tests/test05.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test incr_set and decr_set"
 
-process p1 "exec memcached -p -1 -U 0" -start
+process p1 "exec memcached -u memcached -p -1 -U 0" -start
 
 shell {
 	${vmod_topbuild}/src/tests/gen-vcl.sh ${p1_pid} \


### PR DESCRIPTION
The current memcached command fails if run as root on CentOS 7.  Add memcached user in order to start the server.