### PR TITLE
autotools fix

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -35,9 +35,18 @@ else
 	esac
 fi
 
+# check for varnishapi.m4 in custom paths
+dataroot=$(pkg-config --variable=datarootdir varnishapi 2>/dev/null)
+if [ -z "$dataroot" ] ; then
+	cat >&2 <<'EOF'
+Package varnishapi was not found in the pkg-config search path.
+Perhaps you should add the directory containing `varnishapi.pc'
+to the PKG_CONFIG_PATH environment variable
+EOF
+	exit 1
+fi
 set -ex
-
-aclocal -I m4
+aclocal -I m4 -I ${dataroot}/aclocal
 $LIBTOOLIZE --copy --force
 autoheader
 automake --add-missing --copy --foreign


### PR DESCRIPTION
copying over from libvmod-digest

without it, i get during configure:

```
checking for libvarnishapi... yes
./configure: line 13741: VARNISH_VMOD_INCLUDES: command not found
./configure: line 13742: VARNISH_VMOD_DIR: command not found
./configure: line 13743: VARNISH_VMODTOOL: command not found
```
